### PR TITLE
Use user's native decimal separator

### DIFF
--- a/src/toggl_til_tsv.js
+++ b/src/toggl_til_tsv.js
@@ -13,10 +13,16 @@
 
         return tsv.map(line =>
             line.map(col => typeof col === 'number'
-                ? col === 0 ? '' : col.toFixed(1).replace('.', ',')
+                ? col === 0 ? '' : col.toFixed(1).replace('.', getLocaleDecimalSeparator())
                 : col
             ).join('\t')
         ).join('\n')
+    }
+    
+    function getLocaleDecimalSeparator() {
+        var n = 1.1;
+        n = n.toLocaleString().substring(1, 2);
+        return n;
     }
 
     function split_csv_line(str) {

--- a/src/toggl_til_tsv.js
+++ b/src/toggl_til_tsv.js
@@ -11,18 +11,18 @@
         const tsv = time_entries_to_tsv(time_entries)
         round_to_nearest_half_hour_and_notify_if_rounding_error(tsv)
 
+
+        const locale_decimal_separator = get_locale_decimal_separator();
         return tsv.map(line =>
             line.map(col => typeof col === 'number'
-                ? col === 0 ? '' : col.toFixed(1).replace('.', getLocaleDecimalSeparator())
+                ? col === 0 ? '' : col.toFixed(1).replace('.', locale_decimal_separator)
                 : col
             ).join('\t')
         ).join('\n')
     }
-    
-    function getLocaleDecimalSeparator() {
-        var n = 1.1;
-        n = n.toLocaleString().substring(1, 2);
-        return n;
+
+    function get_locale_decimal_separator() {
+        return 1.1.toLocaleString(navigator.language).substring(1, 2)
     }
 
     function split_csv_line(str) {


### PR DESCRIPTION
Because this is what UBW expects, at least for Bokmål and English. Fixes #5.